### PR TITLE
I extended your extension to add more responsive helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,21 @@ With this extension package you can easily access the MediaQuery sizing info dir
 Size size = context.sizePx;
 ```
 
-It also provides additional convenience methods like landscape state, diagonal screen size and inch-based measurements:
+It also provides additional convenience methods like landscape state, diagonal screen size, inch-based measurements, screen type, width & height percentage, and ratio multipliers for textSize & imageSize:
 
 ```dart
 bool isLandscape = context.isLandscape; //Instead of: MediaQuery.of(context).orientation == Orientation.landscape
 bool isTablet = context.diagonalInches >= 7; //Get physical device size in inches 
-bool useSingleColumn = context.widthPx < 400; //Access .width and .height directly, no need to go throug .size
+bool useSingleColumn = context.widthPx < 400; //Access .width and .height directly, no need to go through .size
+bool isDesktop = context.screenType == ScreenType.Desktop; //Design layouts if Mobile, Tablet or Desktop size
+double sidePadding = context.widthPercent(11.0); //Use percentages of width or height for sizing
+double textScaled = content.textSizeMultiplier * 3.2; //Scale text sizes from ratio of height/100
 ```
 
 ## 🎖 Installation
 ```yaml
 dependencies:
-  sized_context: ^0.1.2
+  sized_context: ^0.2.0
 ```
 
 ### ⚡ Import
@@ -40,6 +43,14 @@ Size sizeInInches = context.sizeInches;
 double widthInInches = context.widthInches;
 double heightInInches = context.heightInches;
 double diagonalInInches = context.diagonalInches;
+//RESPONSIVE HELPERS
+ScreenType screenType = context.screenType;
+double widthPercent = context.widthPercent(10);
+double heightPercent = context.heightPercent(25);
+double textSize = context.textSizeMultiplier * 3.0;
+double imageSize = context.imageSizeMultiplier * 20.0;
+double heightMultiplier = context.heightMultiplier;
+double widthMultiplier = context.widthMultiplier;
 ```
 
 For convenience you can also access the MediaQueryData object directly, to get any other methods or properties:

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -4,44 +4,63 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 extension SizedContext on BuildContext {
-
+  /// Returns same as MediaQuery.of(context)
   MediaQueryData get mq => MediaQuery.of(this);
 
+  /// Returns if Orientation is landscape
   bool get isLandscape => mq.orientation == Orientation.landscape;
 
-  //PIXELS
+  /// Returns same as MediaQuery.of(context).size
   Size get sizePx => mq.size;
+  
+  /// Returns same as MediaQuery.of(context).size.width
   double get widthPx => sizePx.width;
+  
+  /// Returns same as MediaQuery.of(context).height
   double get heightPx => sizePx.height;
 
+  /// Returns diagonal screen pixels
   double get diagonalPx {
     final Size s = sizePx;
     return sqrt((s.width * s.width) + (s.height * s.height));
   }
 
-  //PIXELS
+  /// Returns pixel size in Inches
   Size get sizeInches {
     final Size pxSize = sizePx;
     return Size(pxSize.width / 96, pxSize.height / 96);
   }
 
+  /// Returns screen width in Inches
   double get widthInches => sizeInches.width;
+
+  /// Returns screen height in Inches
   double get heightInches => sizeInches.height;
+
+  /// Returns screen diagonal in Inches
   double get diagonalInches => diagonalPx / 96;
+
+  /// Returns percentage (1-100) of screen width
+  double wp(double percentage) => percentage / 100 * widthPx;
   
-  double wp(percentage) => percentage / 100 * widthPx;
-  double hp(percentage) => percentage / 100 * heightPx;
+  /// Returns percentage (1-100) of screen height
+  double hp(double percentage) => percentage / 100 * heightPx;
+  
+  /// Ratio multiplier for text size (height / 100)
   double get textSizeMultiplier => heightPx / 100.0;
+  
+  /// Ratio multiplier for image size (width / 100)
   double get imageSizeMultiplier => widthPx / 100.0;
+  
+  /// Ratio multiplier of screen height (height / 100)
   double get heightMultiplier => heightPx / 100.0;
+  
+  /// Ratio multiplier of screen width (width / 100)
   double get widgthMultiplier => widthPx / 100.0;
 
+  /// Returns the device ScreenType of Mobile, Tablet or Desktop
   ScreenType get deviceType {
-    double deviceWidth = 0;
-    if (mq.orientation == Orientation.landscape)
-      deviceWidth = heightPx;
-    else
-      deviceWidth = widthPx;
+    double deviceWidth = isLandscape ? heightPx : widthPx;
     if (deviceWidth > 950) return ScreenType.Desktop;
     if (deviceWidth > 600) return ScreenType.Tablet;
     return ScreenType.Mobile;

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -28,4 +28,24 @@ extension SizedContext on BuildContext {
   double get widthInches => sizeInches.width;
   double get heightInches => sizeInches.height;
   double get diagonalInches => diagonalPx / 96;
+  
+  double wp(percentage) => percentage / 100 * widthPx;
+  double hp(percentage) => percentage / 100 * heightPx;
+  double get textSizeMultiplier => heightPx / 100.0;
+  double get imageSizeMultiplier => widthPx / 100.0;
+  double get heightMultiplier => heightPx / 100.0;
+  double get widgthMultiplier => widthPx / 100.0;
+
+  ScreenType get deviceType {
+    double deviceWidth = 0;
+    if (mq.orientation == Orientation.landscape)
+      deviceWidth = heightPx;
+    else
+      deviceWidth = widthPx;
+    if (deviceWidth > 950) return ScreenType.Desktop;
+    if (deviceWidth > 600) return ScreenType.Tablet;
+    return ScreenType.Mobile;
+  }
 }
+
+enum ScreenType { Mobile, Tablet, Desktop }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -41,10 +41,10 @@ extension SizedContext on BuildContext {
   double get diagonalInches => diagonalPx / 96;
 
   /// Returns percentage (1-100) of screen width
-  double wp(double percentage) => percentage / 100 * widthPx;
+  double widthPercent(double percentage) => percentage / 100 * widthPx;
   
   /// Returns percentage (1-100) of screen height
-  double hp(double percentage) => percentage / 100 * heightPx;
+  double heightPercent(double percentage) => percentage / 100 * heightPx;
   
   /// Ratio multiplier for text size (height / 100)
   double get textSizeMultiplier => heightPx / 100.0;
@@ -56,10 +56,10 @@ extension SizedContext on BuildContext {
   double get heightMultiplier => heightPx / 100.0;
   
   /// Ratio multiplier of screen width (width / 100)
-  double get widgthMultiplier => widthPx / 100.0;
+  double get widthMultiplier => widthPx / 100.0;
 
   /// Returns the device ScreenType of Mobile, Tablet or Desktop
-  ScreenType get deviceType {
+  ScreenType get screenType {
     double deviceWidth = isLandscape ? heightPx : widthPx;
     if (deviceWidth > 950) return ScreenType.Desktop;
     if (deviceWidth > 600) return ScreenType.Tablet;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sized_context
 description: Access MediaQuery sizing info directly on the context, also adds some helper methods for sizing and layout.
-version: 0.0.1
+version: 0.2.0
 homepage: https://github.com/gskinnerTeam/flutter-sized-context
 author: Shawn <shawn@gskinner.com>
 


### PR DESCRIPTION
I put together my own SizingInfo class similar to yours, but I liked your implementation better.  Hope you don't mind me transplanting my additional MediaQuery helpers that others should find useful for dealing with responsive screen sizing, especially when trying to adapt ui for big desktop screens.  Here's a quick list of what I added:
  double widthPercent(double percentage) => percentage / 100 * widthPx;
  double heightPercent(double percentage) => percentage / 100 * heightPx;
  double get textSizeMultiplier => heightPx / 100.0;
  double get imageSizeMultiplier => widthPx / 100.0;
  ScreenType get screenType {..}
enum ScreenType { Mobile, Tablet, Desktop }

Plus I added inline documentations for all the functions for you.. Hope ya don't mind my additions, but it does make it a little more useful design pattern.  Feel free to change any of it you want, all's good.  I just love all the cool new tricks we can do with the Dart extensions on anything... Cheers.